### PR TITLE
new api 3.7.0 - adding the ability to display a warning icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log - Power BI Custom Visuals API
 
 ## 3.7.0
-* `displayWarningIcon` : enables visuals to display warning icon with customized text and details.
+* `displayWarningIcon` : enables visuals to display a warning icon with customized text and details.
 
 ## 3.6.0
 * `supportsEmptyDataView` : added the "supportsEmptyDataView" as a capability, enables visuals to receive formatting properties even if they don't have any data roles.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log - Power BI Custom Visuals API
 
+## 3.7.0
+* `displayWarningIcon` : enables visuals to display warning icon with customized text and details.
+
 ## 3.6.0
 * `supportsEmptyDataView` : added the "supportsEmptyDataView" as a capability, enables visuals to receive formatting properties even if they don't have any data roles.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1502,6 +1502,7 @@ declare module powerbi.extensibility.visual {
         eventService: IVisualEventService;
         switchFocusModeState: (on: boolean) => void;
         hostEnv: powerbi.common.CustomVisualHostEnv;
+        displayWarningIcon: (hoverText: string, detailedText: string) => void;
     }
 
     export interface VisualUpdateOptions extends extensibility.VisualUpdateOptions {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "powerbi-visuals-api",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerbi-visuals-api",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "Power BI Custom Visuals API type definitions for typescript",
   "types": "index",
   "main": "index.js",


### PR DESCRIPTION
Adding displayWarningIcon method which allows a visual to display a warning (info icon) to user. The warning is customized meaning the visual can send a title (hoverText) and details (detailedText) to be displayed. The limit of title is 70 characters and the limit of details is 2000 characters. 