### PR TITLE
Updated VisualUpdateType enum to use correct value for ResizeEnd

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,7 @@ declare namespace powerbi {
         Resize = 4,
         ViewMode = 8,
         Style = 16,
-        ResizeEnd = 32,
+        ResizeEnd = 36,
         All = 62,
     }
     const enum VisualPermissions {


### PR DESCRIPTION
This is being passed through as `36` in the `update` method, and as such cannot be trapped through conventional lookup in TypeScript when coded as `32`.