### PR TITLE
Fix inconsistency in typings that cause `pbiviz` to crash when strict typescript is enabled

### DIFF
--- a/src/visuals-api.d.ts
+++ b/src/visuals-api.d.ts
@@ -164,7 +164,7 @@ declare module powerbi.visuals.plugins {
         name: string;
 
         /** Function to call to create the visual. */
-        create: (options?: extensibility.visual.VisualConstructorOptions) => extensibility.IVisual;
+        create: (options: extensibility.visual.VisualConstructorOptions) => extensibility.IVisual;
 
         /** Function to call to create a modal dialog. */
         createModalDialog?: (dialogId: string, options: extensibility.visual.DialogConstructorOptions, initialState: object) => void;


### PR DESCRIPTION
On a newly created project, `pbiviz start` will fail if `strict` is set to `true` in `tsconfig.json`.

This is because a different typing is used in the visual-tools repository: 
https://github.com/microsoft/PowerBI-visuals-tools/blob/0c7562e396e010468230ef43ba187fa0fa4cb791/templates/plugin.ts.template#L10

This PR updates the interface to match the compiled output.

### Error recieved

```
[tsl] ERROR in myVisual\.tmp\precompile\visualPlugin.ts(13,5)
      TS2322: Type '(options: VisualConstructorOptions) => Visual' is not assignable to type '(options?: VisualConstructorOptions | undefined) => IVisual'.
  Types of parameters 'options' and 'options' are incompatible.
    Type 'VisualConstructorOptions | undefined' is not assignable to type 'VisualConstructorOptions'.
      Type 'undefined' is not assignable to type 'VisualConstructorOptions'.
```
