### PR TITLE
Dev/nivalterman/CV api 5.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Change Log - Power BI Custom Visuals API
+## 5.12.0
+* `pendingChanges`: New property which indicates that changes made on the visual are yet to be applied on the report.
 ## 5.11.0
 * Removes storageService.
 ## 5.10.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "powerbi-visuals-api",
-  "version": "5.11.0",
+  "version": "5.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "powerbi-visuals-api",
-      "version": "5.11.0",
+      "version": "5.12.0",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerbi-visuals-api",
-  "version": "5.11.0",
+  "version": "5.12.0",
   "description": "Power BI Custom Visuals API type definitions for typescript",
   "types": "index",
   "main": "index.js",

--- a/src/visuals-api.d.ts
+++ b/src/visuals-api.d.ts
@@ -1029,6 +1029,14 @@ declare module powerbi {
     export interface FilterTypeDescriptor {
         selfFilter?: boolean;
     }
+
+    export const enum PendingChangesType {
+      "Filters",
+    }
+
+    export type PendingChanges = {
+      [key in PendingChangesType]?: boolean;
+    };
 }
 
 
@@ -1845,17 +1853,17 @@ declare module powerbi.extensibility.visual {
     }
 
     export interface VisualUpdateOptions extends extensibility.VisualUpdateOptions {
-        viewport: IViewport;
-        dataViews: DataView[];
-        type: VisualUpdateType;
-        viewMode?: ViewMode;
-        editMode?: EditMode;
-        operationKind?: VisualDataChangeOperationKind;
-        jsonFilters?: IFilter[];
-        isInFocus?: boolean;
-        subSelections?: powerbi.visuals.CustomVisualSubSelection[];
-        formatMode?: boolean;
-        pendingChanges?: boolean;
+      viewport: IViewport;
+      dataViews: DataView[];
+      type: VisualUpdateType;
+      viewMode?: ViewMode;
+      editMode?: EditMode;
+      operationKind?: VisualDataChangeOperationKind;
+      jsonFilters?: IFilter[];
+      isInFocus?: boolean;
+      subSelections?: powerbi.visuals.CustomVisualSubSelection[];
+      formatMode?: boolean;
+      pendingChanges?: PendingChanges;
     }
 
     export interface VisualConstructorOptions extends extensibility.VisualConstructorOptions {

--- a/src/visuals-api.d.ts
+++ b/src/visuals-api.d.ts
@@ -1855,6 +1855,7 @@ declare module powerbi.extensibility.visual {
         isInFocus?: boolean;
         subSelections?: powerbi.visuals.CustomVisualSubSelection[];
         formatMode?: boolean;
+        pendingChanges?: boolean;
     }
 
     export interface VisualConstructorOptions extends extensibility.VisualConstructorOptions {


### PR DESCRIPTION
- API update to 5.12.0
- Added pendingChanges to `options.pendingChanges`
- Added type and enum for pendingChanges to retract the needed fields. (Currently supports only filters with `pendingChanges[Filters]`) 
