### PR TITLE
Add BLEU sovereign cloud to CloudName API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Change Log - Power BI Custom Visuals API
+## 5.11.1
+* `CloudName` : Added BLEU sovereign cloud.
 ## 5.11.0
 * Removes storageService.
 ## 5.10.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "powerbi-visuals-api",
-  "version": "5.11.0",
+  "version": "5.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "powerbi-visuals-api",
-      "version": "5.11.0",
+      "version": "5.11.1",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerbi-visuals-api",
-  "version": "5.11.0",
+  "version": "5.11.1",
   "description": "Power BI Custom Visuals API type definitions for typescript",
   "types": "index",
   "main": "index.js",

--- a/schema.capabilities.json
+++ b/schema.capabilities.json
@@ -161,6 +161,10 @@
                                 "DOD": {
                                     "type": "string",
                                     "description": "Target audience for US Department of Defense Cloud"
+                                },
+                                "BLEU": {
+                                    "type": "string",
+                                    "description": "Target audience for Bleu Sovereign Cloud"
                                 }
                             },
                             "required": [

--- a/src/visuals-api.d.ts
+++ b/src/visuals-api.d.ts
@@ -1555,6 +1555,7 @@ declare module powerbi.extensibility {
         GCC = "GCC",         // US Government Community Cloud
         GCCHIGH = "GCCHIGH", // US Government Community Cloud High
         DOD = "DOD",         // US Department of Defense Cloud
+        BLEU = "BLEU",       // Bleu Sovereign Cloud
     }
 
     /**


### PR DESCRIPTION
- Add BLEU to the CloudName enum

- Add BLEU target audience mapping to capabilities schema

- Bump version to 5.11.1 and update CHANGELOG